### PR TITLE
Add Dockerfile for Python 3.10 setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv for fast dependency installation
+RUN pip install --no-cache-dir uv
+
+# Set work directory
+WORKDIR /app
+
+# Copy project files
+COPY . /app
+
+# Install Python dependencies
+RUN uv pip install --no-cache-dir -r requirements.txt
+
+# Default command shows CLI help
+CMD ["python", "src/clean_debate_audio.py", "-h"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # debate-audio-cleaner
 
+
+## Docker usage
+
+Build the image:
+
+```bash
+docker build -t debate-audio-cleaner .
+```
+
+Run the cleaner on a YouTube video:
+
+```bash
+docker run --rm -v "$(pwd)/output:/app/output" debate-audio-cleaner \
+  python src/clean_debate_audio.py "https://youtu.be/VIDEO_ID" --gpu
+```
+
+The default command displays CLI help:
+
+```bash
+docker run --rm debate-audio-cleaner
+```


### PR DESCRIPTION
## Summary
- add Dockerfile using Python 3.10 and uv for dependency installation
- update README with Docker usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a847379188323bc218451ff06ab1d